### PR TITLE
Update MorasDBConverter.py

### DIFF
--- a/MorasDBConverter.py
+++ b/MorasDBConverter.py
@@ -218,7 +218,7 @@ def main():
     connection = sqlite3.connect(args.output)
     create_db(connection)
 
-    with open(args.database) as json_file:
+    with open(args.database, encoding='latin1') as json_file:
         print("Loading '%s' ..." % args.database)
         data = json.load(json_file)
         print("Done loading '%s' ..." % args.database)


### PR DESCRIPTION
Fix 'UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe7 in position 16267869: invalid continuation byte' error on latest downloadable DB (Feb-2021)